### PR TITLE
fix: Convert class attributes to className in TSX markup

### DIFF
--- a/src/components/react/FormattedDate.tsx
+++ b/src/components/react/FormattedDate.tsx
@@ -4,7 +4,7 @@ import React from 'react'
 function FormattedDate({ date }: { date: string }) {
 	const _date = new Date(date)
 	return (
-		<time datetime={_date.toISOString()}>
+		<time dateTime={_date.toISOString()}>
 			{
 				_date.toLocaleDateString('en-us', {
 					year: 'numeric',

--- a/tina/pages/AdminBlogPost.tsx
+++ b/tina/pages/AdminBlogPost.tsx
@@ -23,16 +23,16 @@ export default function AdminBlogPost(props: Props) {
 
 	return (
 		<article>
-			<div data-tina-field={tinaField(blog, "heroImage")} class="hero-image">
+			<div data-tina-field={tinaField(blog, "heroImage")} className="hero-image">
 				{blog.heroImage && <img width={1020} height={510} src={blog.heroImage} alt="" />}
 			</div>
-			<div class="prose">
-				<div class="title">
-					<div class="date" data-tina-field={tinaField(blog, "pubDate")} >
+			<div className="prose">
+				<div className="title">
+					<div className="date" data-tina-field={tinaField(blog, "pubDate")} >
 						<FormattedDate date={blog.pubDate} />
 						{
 							blog.updatedDate && (
-								<div class="last-updated-on" data-tina-field={tinaField(blog, "updatedDate")} >
+								<div className="last-updated-on" data-tina-field={tinaField(blog, "updatedDate")} >
 									Last updated on <FormattedDate date={blog.updatedDate} />
 								</div>
 							)


### PR DESCRIPTION
- Replace HTML class attribute with React's className property
- Fixes "Invalid DOM property" warning
- Ensures proper JSX/TSX syntax compliance

Resolves warning: "Invalid DOM property `class`. Did you mean `className`?"