### PR TITLE
fix: Convert datetime attribute to dateTime in FormattedDate component

### DIFF
--- a/src/components/react/FormattedDate.tsx
+++ b/src/components/react/FormattedDate.tsx
@@ -4,7 +4,7 @@ import React from 'react'
 function FormattedDate({ date }: { date: string }) {
 	const _date = new Date(date)
 	return (
-		<time datetime={_date.toISOString()}>
+		<time dateTime={_date.toISOString()}>
 			{
 				_date.toLocaleDateString('en-us', {
 					year: 'numeric',


### PR DESCRIPTION
- Replace HTML datetime attribute with React's dateTime property
- Fixes "Invalid DOM property" warning in FormattedDate.tsx
- Ensures proper JSX/TSX camelCase property naming

Resolves warning: "Invalid DOM property `datetime`. Did you mean `dateTime`?"