### PR TITLE
🐛 Bug - Remove unnecessary redirect leading to infinite loop

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -9,7 +9,4 @@ import tinaDirective from "./astro-tina-directive/register"
 export default defineConfig({
 	site: process.env.SITE_URL || `https://${process.env.VERCEL_URL}`,
 	integrations: [mdx(), sitemap(), react(), tinaDirective()],
-	redirects: {
-		'/admin': '/admin/index.html'
-	  }
 });


### PR DESCRIPTION
We have received [reports of users](https://discord.com/channels/835168149439643678/1069976809950683177/threads/1353136525088657470) experiencing an infinite loop when attempting to access the TinaCMS admin page.

This removes the redirect from "/admin" to "/admin/index.html", which appears to be unnecessary.