### PR TITLE
feat: add build-local script, align @tinacms/cli to 2.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "tinacms dev -c \"astro dev\"",
     "build": "tinacms build && astro build",
+    "build-local": "tinacms build --content=local --skip-cloud-checks -c \"astro build\"",
     "preview": "astro preview",
     "astro": "astro"
   },
@@ -18,10 +19,10 @@
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-icons": "^5.5.0",
-    "tinacms": "^3.3.2"
+    "tinacms": "^3.8.1"
   },
   "devDependencies": {
-    "@tinacms/cli": "^2.1.2",
+    "@tinacms/cli": "^2.3.1",
     "@types/node": "^25.1.0"
   }
 }


### PR DESCRIPTION
## Summary

Adds a `build-local` script and bumps the package.json minimums to match what the lockfile is already resolving to:

```diff
  "build": "tinacms build && astro build",
+ "build-local": "tinacms build --content=local --skip-cloud-checks -c \"astro build\"",

- "@tinacms/cli": "^2.1.2",
+ "@tinacms/cli": "^2.3.1",

- "tinacms": "^3.3.2"
+ "tinacms": "^3.8.1"
```

## Why

The other Tina starters ship a `build-local` script that lets contributors and CI build the project without provisioning a real TinaCloud project. This one doesn't — so reproducing a build locally requires either a Tina Cloud account or hand-rolling the right CLI invocation.

The `--content=local` flag (added in `@tinacms/cli@2.3.0` via [tinacms/tinacms#6636](https://github.com/tinacms/tinacms/pull/6636)) is the right tool: it indexes content from the filesystem during the build so no GraphQL network calls happen, but generates a production-shaped client that points at TinaCloud at runtime — so the build artifact is deployable as-is.

This makes the template:

- **Fork-PR-safe in CI smoke tests** — works with dummy `PUBLIC_TINA_CLIENT_ID` / `TINA_TOKEN` env vars
- **Faster to build locally** for users who have content checked in
- **Verifiable end-to-end** without provisioning a cloud project

## Note on the version bump

The shipped `pnpm-lock.yaml` was already resolving `@tinacms/cli` to 2.3.1 and `tinacms` to 3.8.1 despite the lower carets in `package.json` — so this PR mostly aligns the declared minimums with reality. The carets were a couple of minors behind for no real reason.

## Verification

```
PUBLIC_TINA_CLIENT_ID=fake-id-for-smoke \
TINA_TOKEN=fake-token-for-smoke \
GITHUB_BRANCH=main \
pnpm run build-local
```

Result: **✓ 9 pages built clean** (`/blog/*`, `/about`, `/home`, `/`, rss.xml, sitemap), zero Tina Cloud network calls.

## Test plan

- [ ] CI: `pnpm install` resolves to `@tinacms/cli@2.3.1` and `tinacms@3.8.1`
- [ ] `pnpm run build` still works with real Tina Cloud creds (unchanged script)
- [ ] `pnpm run build-local` works with dummy/no creds
- [ ] `pnpm run dev` still works (unchanged script)

🤖 Generated with [Claude Code](https://claude.com/claude-code)