### PR TITLE
docs: point admin URL to /admin/index.html

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is a [Tina CMS](https://tina.io/) starter project.
 npx create-tina-app@latest --template tina-astro-starter
 ```
 
-And start editing with TinaCMS at `/admin`! 
+And start editing with TinaCMS at `/admin/index.html` (in dev, `astro dev` won't serve `/admin` directly)! 
 
 
 > 🧑‍🚀 **Seasoned astronaut?** Delete this file. Have fun!

--- a/src/content/page/home.mdx
+++ b/src/content/page/home.mdx
@@ -9,7 +9,7 @@ This template comes with a few integrations already configured in your `astro.co
 
 Here are a few ideas on how to get started with the template:
 
-* **Edit this page**: Navigate to `/admin` to update your homepage content in TinaCMS or manually edit `src/pages/index.astro` for full control.
+* **Edit this page**: Navigate to `/admin/index.html` to update your homepage content in TinaCMS or manually edit `src/pages/index.astro` for full control.
 * **Site Header**: Customize the navigation items in TinaCMS under the **Config Collection** or via `src/components/Header.astro`.
 * **Site Footer**: Make it yours by adding your name or details in TinaCMS Global Config.
 * **Explore Blog Posts**: Check out sample posts in `src/content/blog` to see how content is structured or edit them in TinaCMS under the **Blog Collection**.


### PR DESCRIPTION
## What

Updates the README and home page content to reference `/admin/index.html` instead of `/admin` as the dev URL for the TinaCMS admin.

## Why

`astro dev` doesn't serve directory index files from `public/`, so the admin SPA that Tina writes to `public/admin/index.html` is only reachable at its literal path — `/admin/index.html`. Visiting `/admin` 404s in dev (no route maps to it, and the dev server won't auto-resolve the directory index), which trips up new users.

This is a dev-only quirk: after `astro build`, `dist/admin/index.html` is a static file that hosts like Vercel/Netlify serve at `/admin` automatically, so production is unaffected.

## Changes

- `README.md` — `/admin` → `/admin/index.html`
- `src/content/page/home.mdx` — same

## Related

Addresses tinacms/tinacms#6931 (cross-repo, so it won't auto-close — leaving that to a maintainer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)