### PR TITLE
fix: pin react to v18 to resolve ReactCurrentDispatcher crash

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,5 +24,19 @@
     "@tinacms/cli": "^2.4.0",
     "@types/node": "^25.9.1",
     "tinacms": "^3.8.2"
+  },
+  "overrides": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "resolutions": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "pnpm": {
+    "overrides": {
+      "react": "^18.3.1",
+      "react-dom": "^18.3.1"
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Adds dependency overrides (`overrides`, `resolutions`, `pnpm.overrides`) to pin `react` and `react-dom` to `^18.3.1`
- Fixes a crash where `@astrojs/vercel` → `@vercel/analytics` pulls in `react@19.0.0-rc`, which is incompatible with `react-dom@18` used by TinaCMS
- Covers npm, yarn, and pnpm so all users of this starter are unblocked

Closes #38

## Test plan
- [ ] `pnpm install && pnpm dev` — dev server starts without `ReactCurrentDispatcher` error
- [ ] `npm install && npm run dev` — same
- [ ] `yarn install && yarn dev` — same
- [ ] Verify TinaCMS admin panel loads at `/admin/index.html`

🤖 Generated with [Claude Code](https://claude.com/claude-code)