### PR TITLE
fix: add explicit react 18 deps to prevent version mismatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,12 @@ All commands are run from the root of the project, from a terminal:
 | `npm run astro ...`       | Run CLI commands like `astro add`, `astro check` |
 | `npm run astro -- --help` | Get help using the Astro CLI                     |
 
+## Why does `package.json` pin `react` and `react-dom`?
+
+The Astro site itself is React-free — `@tinacms/astro` ships React-free visual editing. The pinned `react` / `react-dom@^18.3.1` in `devDependencies` exist only so the TinaCMS admin UI (which is a React app, built at dev/CI time by `tinacms build` into `public/admin/`) gets a React version matching the `react-dom@^18.3.1` peer that `tinacms` requires.
+
+Without these pins, pnpm's `auto-install-peers` resolves `react@19.0.0-rc` (to satisfy `@vercel/analytics`'s wide optional peer range) and pairs it with `react-dom@18.3.1`, which crashes at module init with `Cannot read properties of undefined (reading 'ReactCurrentDispatcher')`. Don't remove these pins until TinaCMS declares `react` / `react-dom` as direct deps of `@tinacms/cli` ([tinacms#6985](https://github.com/tinacms/tinacms/issues/6985)) — once that lands, this workaround can go.
+
 ## 👀 Want to learn more?
 
 Check out the [TinaCMS documentation](https://tina.io/docs) and the [Astro documentation](https://docs.astro.build) or jump into our [TinaCMS Discord server](https://discord.gg/cG2UNREu).

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
     "astro": "^6.3.7",
     "astro-icon": "^1.1.5",
     "clsx": "^2.1.1",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
     "tailwind-merge": "^3.6.0",
     "tailwind-variants": "^3.2.2",
     "tailwindcss": "^4.3.0"

--- a/package.json
+++ b/package.json
@@ -23,8 +23,6 @@
     "astro": "^6.3.7",
     "astro-icon": "^1.1.5",
     "clsx": "^2.1.1",
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1",
     "tailwind-merge": "^3.6.0",
     "tailwind-variants": "^3.2.2",
     "tailwindcss": "^4.3.0"
@@ -33,6 +31,8 @@
     "@astrojs/check": "^0.9.9",
     "@tinacms/cli": "^2.4.0",
     "@types/node": "^25.9.1",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
     "tinacms": "^3.8.2",
     "typescript": "^6.0.3"
   }


### PR DESCRIPTION
## Summary
- Adds `react` and `react-dom` at `^18.3.1` as explicit dependencies
- Fixes #44 — TinaCMS dev server crashes with `ReactCurrentDispatcher` error because pnpm (and other package managers) auto-resolve `react@19.0.0-rc` via `@vercel/analytics` while `tinacms` pins `react-dom` to `^18.3.1`

## Test plan
- [x] `pnpm install && pnpm dev` — TinaCMS dev server starts without errors
- [x] `npm install && npm run dev` — same
- [x] `yarn install && yarn dev` — same

🤖 Generated with [Claude Code](https://claude.com/claude-code)