### PR TITLE
fix: allow pnpm 10+ to run dependency build scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,8 +39,5 @@
     "react-dom": "^18.3.1",
     "tinacms": "^3.8.2",
     "typescript": "^6.0.3"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": ["better-sqlite3", "core-js", "esbuild", "protobufjs", "sharp"]
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,5 +39,8 @@
     "react-dom": "^18.3.1",
     "tinacms": "^3.8.2",
     "typescript": "^6.0.3"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": ["better-sqlite3", "core-js", "esbuild", "protobufjs", "sharp"]
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,12 @@
+onlyBuiltDependencies:
+  - better-sqlite3
+  - core-js
+  - esbuild
+  - protobufjs
+  - sharp
+allowBuilds:
+  better-sqlite3: true
+  core-js: true
+  esbuild: true
+  protobufjs: true
+  sharp: true


### PR DESCRIPTION
## Problem

On a fresh `pnpm install`, build scripts for native/postinstall deps are blocked by default, leaving binaries unbuilt and breaking dev/build:

```
ERR_PNPM_IGNORED_BUILDS  Ignored build scripts: better-sqlite3, core-js, esbuild, protobufjs, sharp
```

`sharp` is a direct dep; the rest arrive via `@tinacms/cli` / `tinacms`. Also surfaces downstream in `create-tina-app` (tinacms/tinacms#7031).

## Fix

Add a build-script allowlist in **`pnpm-workspace.yaml`** (pnpm 11 no longer reads the `pnpm` field in `package.json`, and renamed `onlyBuiltDependencies` → `allowBuilds`). Both keys are included so it works across pnpm 10 and 11:

```yaml
onlyBuiltDependencies:   # pnpm 10
  - better-sqlite3
  - core-js
  - esbuild
  - protobufjs
  - sharp
allowBuilds:             # pnpm 11
  better-sqlite3: true
  core-js: true
  esbuild: true
  protobufjs: true
  sharp: true
```

List confirmed against the current lockfile (`protobufjs` added — newer lockfile than the original issue).

## Verify

`rm -rf node_modules && pnpm install` — no `ERR_PNPM_IGNORED_BUILDS`, build scripts run. Tested clean on both pnpm 10.25.0 and pnpm 11.5.1 ✅

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)