### PR TITLE
🐛 Fix #55: render MDX tables (bump @tinacms/astro) and correct TinaCMS product name

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@iconify-json/tabler": "^1.2.35",
     "@tailwindcss/typography": "^0.5.19",
     "@tailwindcss/vite": "^4.3.0",
-    "@tinacms/astro": "^0.4.1",
+    "@tinacms/astro": "^0.5.0",
     "astro": "^6.4.4",
     "astro-icon": "^1.1.5",
     "clsx": "^2.1.1",

--- a/src/content/blog/content-modeling.mdx
+++ b/src/content/blog/content-modeling.mdx
@@ -1,12 +1,12 @@
 ---
-title: Modeling content with Tina collections
-description: Define your content shape once in the Tina schema, and get editing forms, validation, and a typed API for free.
+title: Modeling content with TinaCMS collections
+description: Define your content shape once in the TinaCMS schema, and get editing forms, validation, and a typed API for free.
 pubDate: 2026-03-10T09:00:00.000Z
 updatedDate: 2026-05-20T09:00:00.000Z
 heroImage: /blog-placeholder-2.jpg
 ---
 
-In Tina, your content model is code. You describe the shape of a piece of content once, in the `tina/` directory, and Tina turns that description into three things at once: the editing forms writers use, the validation that keeps content clean, and a typed GraphQL API your pages query.
+In TinaCMS, your content model is code. You describe the shape of a piece of content once, in the `tina/` directory, and TinaCMS turns that description into three things at once: the editing forms writers use, the validation that keeps content clean, and a typed GraphQL API your pages query.
 
 ## Collections and fields
 
@@ -28,11 +28,11 @@ export const BlogCollection = {
 };
 ```
 
-Every field you see in the editor sidebar comes from this list. Mark a field `required` and Tina enforces it. Mark one `isTitle` and it becomes the document's display name. Mark one `isBody` and its content becomes the Markdown body of the file rather than frontmatter.
+Every field you see in the editor sidebar comes from this list. Mark a field `required` and TinaCMS enforces it. Mark one `isTitle` and it becomes the document's display name. Mark one `isBody` and its content becomes the Markdown body of the file rather than frontmatter.
 
 ## Field types do the heavy lifting
 
-Tina ships a rich set of field types so the editing experience matches the data:
+TinaCMS ships a rich set of field types so the editing experience matches the data:
 
 - `string` and `rich-text` for text, with the latter giving a full WYSIWYG editor.
 - `datetime`, `boolean`, and `number` for structured values, each with a fitting input.

--- a/src/content/blog/git-backed-content.mdx
+++ b/src/content/blog/git-backed-content.mdx
@@ -5,7 +5,7 @@ pubDate: 2026-04-08T09:00:00.000Z
 heroImage: /blog-placeholder-5.jpg
 ---
 
-The defining choice in TinaCMS is where your content is stored. Instead of a hosted database, your content is a set of Markdown, MDX, and JSON files in your repository. When an editor saves, Tina writes the file and commits it. That single decision shapes nearly everything else about the workflow.
+The defining choice in TinaCMS is where your content is stored. Instead of a hosted database, your content is a set of Markdown, MDX, and JSON files in your repository. When an editor saves, TinaCMS writes the file and commits it. That single decision shapes nearly everything else about the workflow.
 
 ## What you get for free
 
@@ -13,15 +13,15 @@ Because your content is just files under version control, it inherits the tools 
 
 - **History and blame.** Every change has an author, a timestamp, and a diff. You can see who changed a headline and revert it in seconds.
 - **Branches and previews.** Draft a campaign on a branch, open a pull request, and review the rendered result on a deploy preview before it touches production.
-- **No lock-in.** Your content is portable Markdown. If you ever move off Tina, the files are right there, readable without any export step.
+- **No lock-in.** Your content is portable Markdown. If you ever move off TinaCMS, the files are right there, readable without any export step.
 - **One source of truth.** Code and content travel together, so a deploy is always a consistent snapshot of both.
 
 ## How a save flows
 
 The path from edit to published is short and legible:
 
-1. An editor changes a field in the Tina sidebar.
-2. Tina writes the value to the underlying file.
+1. An editor changes a field in the TinaCMS sidebar.
+2. TinaCMS writes the value to the underlying file.
 3. The change is committed to Git, locally in dev or through TinaCloud in production.
 4. Your host rebuilds from the new commit, and the change goes live.
 
@@ -29,4 +29,4 @@ The path from edit to published is short and legible:
 
 A Git-backed model is not a database, and that is the point. You get auditability, review, and portability instead of arbitrary real-time queries. For a content site, a blog, docs, or marketing pages, that trade is almost always the right one, and it is exactly what this starter is built around.
 
-If you are writing that content by hand, it helps to know [how Markdown and MDX render through Tina](/blog/markdown-and-mdx/).
+If you are writing that content by hand, it helps to know [how Markdown and MDX render through TinaCMS](/blog/markdown-and-mdx/).

--- a/src/content/blog/markdown-and-mdx.mdx
+++ b/src/content/blog/markdown-and-mdx.mdx
@@ -1,11 +1,11 @@
 ---
-title: Writing with Markdown and MDX in Tina
-description: How Tina's rich-text editor maps to the Markdown and MDX it saves, with a tour of the formatting you can use in a post body.
+title: Writing with Markdown and MDX in TinaCMS
+description: How the TinaCMS rich-text editor maps to the Markdown and MDX it saves, with a tour of the formatting you can use in a post body.
 pubDate: 2026-05-06T09:00:00.000Z
 heroImage: /blog-placeholder-1.jpg
 ---
 
-When you edit a post body in TinaCMS, you are using a rich-text editor: headings, lists, links, and quotes all behave the way they would in any document tool. Behind the scenes, Tina saves that body as Markdown (or MDX) in the file, so what you write stays portable and readable outside the CMS. This post doubles as a reference for the formatting that body supports and a demo of how it renders on this site.
+When you edit a post body in TinaCMS, you are using a rich-text editor: headings, lists, links, and quotes all behave the way they would in any document tool. Behind the scenes, TinaCMS saves that body as Markdown (or MDX) in the file, so what you write stays portable and readable outside the CMS. This post doubles as a reference for the formatting that body supports and a demo of how it renders on this site.
 
 ## Headings
 
@@ -25,9 +25,9 @@ The body supports six levels of heading, from `<h1>` down to `<h6>`. Use them to
 
 ## Paragraph text
 
-Body copy is the default. Tina stores it as plain Markdown paragraphs, and this starter renders it through the typography styles defined in `global.css`, so it stays legible in both light and dark themes. Keep paragraphs focused; a single idea each reads far better on screen than a wall of text.
+Body copy is the default. TinaCMS stores it as plain Markdown paragraphs, and this starter renders it through the typography styles defined in `global.css`, so it stays legible in both light and dark themes. Keep paragraphs focused; a single idea each reads far better on screen than a wall of text.
 
-You can mark words as *italic*, **bold**, or `inline code` without leaving the editor, and Tina writes the matching Markdown for each.
+You can mark words as *italic*, **bold**, or `inline code` without leaving the editor, and TinaCMS writes the matching Markdown for each.
 
 ## Links
 
@@ -44,7 +44,7 @@ Use a blockquote to set off a quotation or an aside from the surrounding text.
 
 Ordered lists are good for steps:
 
-1. Define a collection in the Tina schema.
+1. Define a collection in the TinaCMS schema.
 2. Add the fields your content needs.
 3. Edit the content in the sidebar and save.
 
@@ -65,7 +65,7 @@ Lists can nest when the structure calls for it:
 
 ## Code blocks
 
-Fenced code blocks keep technical posts precise, and Tina preserves the language hint so syntax highlighting works:
+Fenced code blocks keep technical posts precise, and TinaCMS preserves the language hint so syntax highlighting works:
 
 ```html
 <!doctype html>
@@ -90,4 +90,4 @@ Tables render from standard Markdown, which is handy for small comparisons:
 | MDX       | Rich-text       | Git      |
 | JSON      | Structured form | Git      |
 
-That is the full range of formatting a post body can use. Write it however feels natural in the editor; Tina handles turning it into clean Markdown on the way to your repo.
+That is the full range of formatting a post body can use. Write it however feels natural in the editor; TinaCMS handles turning it into clean Markdown on the way to your repo.

--- a/src/content/blog/visual-editing.mdx
+++ b/src/content/blog/visual-editing.mdx
@@ -9,7 +9,7 @@ The gap between a CMS form and the page it produces is where mistakes live. You 
 
 ## How it works
 
-When you run the site with Tina's dev server and open `/admin`, Tina mounts a sidebar next to your real pages. Click any connected piece of content and the form for that field opens, with your edits reflected on the page as you type. There is no separate preview to refresh and no mental mapping between a field name and where it shows up.
+When you run the site with the TinaCMS dev server and open `/admin`, TinaCMS mounts a sidebar next to your real pages. Click any connected piece of content and the form for that field opens, with your edits reflected on the page as you type. There is no separate preview to refresh and no mental mapping between a field name and where it shows up.
 
 The connection between a page element and its content is made with a single attribute:
 

--- a/src/content/blog/why-tinacms.mdx
+++ b/src/content/blog/why-tinacms.mdx
@@ -7,17 +7,17 @@ heroImage: /blog-placeholder-3.jpg
 
 Most content management systems ask you to make a trade. You either get a friendly editing interface and hand your content to a database you do not own, or you keep your content in the repo as Markdown and lose the visual editing your non-technical teammates need. TinaCMS refuses that trade.
 
-TinaCMS is an open-source CMS that stores your content as Markdown, MDX, and JSON files committed directly to your Git repository. There is no separate content database to sync, back up, or migrate away from later. The files in `src/content` are the single source of truth, and Tina is the editing layer on top of them.
+TinaCMS is an open-source CMS that stores your content as Markdown, MDX, and JSON files committed directly to your Git repository. There is no separate content database to sync, back up, or migrate away from later. The files in `src/content` are the single source of truth, and TinaCMS is the editing layer on top of them.
 
 ## What you actually get
 
 - **Visual editing in context.** Editors click directly on the text and images they want to change, on the real page, and watch updates appear as they type.
-- **A typed content schema.** You define collections and fields in code, and Tina generates the editing forms and a GraphQL API to match.
+- **A typed content schema.** You define collections and fields in code, and TinaCMS generates the editing forms and a GraphQL API to match.
 - **Git as your backend.** Every save is a commit, so your content carries the same history, branching, and review workflow as your code.
-- **Framework freedom.** Tina works with Astro, Next.js, Hugo, and more. This starter pairs it with Astro for fast, content-first pages.
+- **Framework freedom.** TinaCMS works with Astro, Next.js, Hugo, and more. This starter pairs it with Astro for fast, content-first pages.
 
 ## Who it is for
 
-Tina fits teams where developers own the build and writers own the words. Developers get a schema they control and content that never leaves the repo. Writers get an interface that feels like editing the live site, not filling out a form in an unfamiliar dashboard.
+TinaCMS fits teams where developers own the build and writers own the words. Developers get a schema they control and content that never leaves the repo. Writers get an interface that feels like editing the live site, not filling out a form in an unfamiliar dashboard.
 
 The rest of this blog walks through the pieces that make that possible: [editing in context](/blog/visual-editing/), [modeling your content](/blog/content-modeling/), and [keeping everything in Git](/blog/git-backed-content/).

--- a/src/content/page/about.mdx
+++ b/src/content/page/about.mdx
@@ -4,7 +4,7 @@ blocks:
   - _template: split
     title: Editing that happens in context
     body: |
-      Tina renders your real site, then lets you click any heading, paragraph, or image and change it in place. What you edit is exactly what visitors see - no separate preview, no guesswork.
+      TinaCMS renders your real site, then lets you click any heading, paragraph, or image and change it in place. What you edit is exactly what visitors see - no separate preview, no guesswork.
 
       Behind the scenes every change is a commit, so your content has the same history, branches, and review as the rest of your codebase.
     image:
@@ -19,7 +19,7 @@ blocks:
     body: |
       ## Content management, the way it should be
 
-      Tina exists to settle an old argument. Developers want control, editors want simplicity, and for years a CMS made you choose one or the other. We never accepted that trade-off.
+      TinaCMS exists to settle an old argument. Developers want control, editors want simplicity, and for years a CMS made you choose one or the other. We never accepted that trade-off.
 
       So we built a CMS on top of the tools developers already trust - Git and Markdown - and gave content creators a live, visual way to work inside them. No proprietary database. No content held hostage. Just your words, in your repository, editable by anyone on the team.
   - _template: callout
@@ -32,7 +32,7 @@ blocks:
       - icon: code
         title: Developer-first
         text: |
-          Define your schema in TypeScript and wire up the editor exactly how you want it. Tina bends to your stack, not the other way around.
+          Define your schema in TypeScript and wire up the editor exactly how you want it. TinaCMS bends to your stack, not the other way around.
       - icon: wand
         title: Editor-friendly
         text: |
@@ -53,7 +53,7 @@ blocks:
         type: Your single source of truth
   - _template: cta
     title: Help shape what comes next
-    description: 'Tina is open source and built in the open. Read the docs, join the conversation, and help define the future of Git-based content.'
+    description: 'TinaCMS is open source and built in the open. Read the docs, join the conversation, and help define the future of Git-based content.'
     actions:
       - label: Read the Docs
         type: button

--- a/src/content/page/home.mdx
+++ b/src/content/page/home.mdx
@@ -51,7 +51,7 @@ blocks:
       LLMs think in it. Your CMS should too. TinaCMS stores everything as Markdown in Git, so your content stays open, portable, and ready for whatever comes next.
     _template: content
   - title: Loved by developers and editors
-    description: The teams who ship on Astro and Tina keep coming back for the same reason. A fast site their whole team can actually edit.
+    description: The teams who ship on Astro and TinaCMS keep coming back for the same reason. A fast site their whole team can actually edit.
     testimonials:
       - quote: 'I made a whole website and I don''t even have computer hacking skills. You just click the words right on the page and type new ones. Gosh, it''s flippin'' sweet.'
         author: Napoleon Dynamite
@@ -59,7 +59,7 @@ blocks:
       - quote: 'I love technology, and this is the sweetest setup I''ve found online. The content lives in Git, so nothing ever gets lost, not even my chat logs with LaFawnduh.'
         author: Kip Dynamite
         role: Online entrepreneur
-      - quote: 'I built my whole campaign site in one night. If you want all your wildest dreams to come true, ship it on Astro and Tina.'
+      - quote: 'I built my whole campaign site in one night. If you want all your wildest dreams to come true, ship it on Astro and TinaCMS.'
         author: Pedro Sánchez
         role: Class president
     _template: testimonial


### PR DESCRIPTION
## What hurts

The live starter demo misrepresents the product two ways (#55): MDX tables are silently dropped from post bodies — the [markdown-and-mdx post](https://tina-astro-starter.vercel.app/blog/markdown-and-mdx/) introduces its comparison table and then renders nothing — and the copy calls the product "Tina" instead of "TinaCMS" across the blog posts and pages, right down to the post title "Writing with Markdown and MDX in Tina".

The table half is a version gap: `@tinacms/astro` 0.4.x has no renderer for table nodes; tinacms/tinacms#7041 added one, released as 0.5.0 — but the starter pins `^0.4.1`, and caret ranges don't cross 0.x minors, so even a fresh deploy never picks it up.

## What this does

- Bumps `@tinacms/astro` to `^0.5.0`, which renders MDX tables with no starter-side workaround.
- Replaces every bare "Tina" with "TinaCMS" in rendered site copy (5 blog posts + home/about), rephrasing the two "Tina's" possessives naturally. Code comments and the "Tina-ember" theme name are deliberately left alone.

Closes #55.

### Notes worth your call

- This supersedes #61: the upstream renderer replaces its `Table.astro` workaround, and the copy pass here covers more than its content changes (which missed the post title, re-churned bullet styles, and carried a leftover `<cta>` test artifact).

### Test plan

- [x] `pnpm install && pnpm run build:local` succeeds (Node 22.22.0)
- [x] Built `blog/markdown-and-mdx/index.html` contains the `<table>` with all cells
- [x] Zero bare "Tina" occurrences in any built HTML page (scripted scan over `dist/client`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)