### PR TITLE
fix: make pnpm-workspace.yaml installable on pnpm <10.5.0 (Corepack default)

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,8 @@
+# Not a monorepo — `packages` is only here so pnpm <10.5.0 accepts this
+# settings file instead of failing with "packages field missing or empty".
+packages:
+  - '.'
+
 onlyBuiltDependencies:
   - better-sqlite3
   - core-js


### PR DESCRIPTION
## What

Adds `packages: ['.']` to `pnpm-workspace.yaml` (plus a comment explaining why).

## Why

A fresh clone — and any `create-tina-app` scaffold where the user picks pnpm — fails on `pnpm install` whenever pnpm is older than **10.5.0**:

```
ERROR  packages field missing or empty
```

The config-only `pnpm-workspace.yaml` added in d6afe3d (to hold the build-script allowlist for pnpm 11) is read as a monorepo by pre-10.5.0 pnpm, which then demands a non-empty `packages:` field. It became optional in pnpm 10.5.0 ([pnpm#8968](https://github.com/pnpm/pnpm/issues/8968)), so 9.x and 10.0–10.4.x all trip on it. Corepack's bundled default is still **pnpm 9.15.9**, so `corepack pnpm install` fails out of the box.

`packages: ['.']` makes every pnpm version accept the file as a single-package install. The allowlist keys are untouched, so native builds still work on pnpm 10 and 11.

### Why not pin `packageManager`?

`create-tina-app` lets users choose pnpm / yarn / bun / npm and just runs `<chosen-pm> install` — it doesn't write a `packageManager` field. Pinning `pnpm` here would force Corepack onto pnpm for everyone, including the yarn/npm/bun paths. This fix stays package-manager-agnostic: npm/yarn/bun ignore `pnpm-workspace.yaml` entirely.

## Verification

Clean `install` on a fresh tree:

| pnpm | result |
|------|--------|
| 9.15.9 (Corepack default) | ✅ |
| 10.34.1 | ✅ |
| 11.5.2 | ✅ |

Closes tinacms/tinacms#7048