### PR TITLE
fix: detect branch on Cloudflare (Workers Builds and Pages)

### DIFF
--- a/tina/config.ts
+++ b/tina/config.ts
@@ -7,7 +7,9 @@ import { PageCollection } from "./collections/page";
 const branch =
   process.env.GITHUB_BRANCH ||
   process.env.VERCEL_GIT_COMMIT_REF ||
-  process.env.HEAD ||
+  process.env.WORKERS_CI_BRANCH || // Cloudflare Workers Builds
+  process.env.CF_PAGES_BRANCH || // Cloudflare Pages
+  process.env.HEAD || // Netlify
   "main";
 
 export default defineConfig({


### PR DESCRIPTION
`tina/config.ts` resolves the editing branch from the host's git environment variable, but the chain read no Cloudflare variable:

```js
const branch =
  process.env.GITHUB_BRANCH ||
  process.env.VERCEL_GIT_COMMIT_REF ||
  process.env.HEAD ||
  "main";
```

Cloudflare sets none of those. Workers Builds exposes the branch as `WORKERS_CI_BRANCH` and Pages as `CF_PAGES_BRANCH`, so `branch` always fell back to `"main"` on Cloudflare. Vercel worked because `VERCEL_GIT_COMMIT_REF` is handled, which made this easy to miss.

Impact: a production-from-`main` deploy is fine, but a non-`main` production branch or a preview deploy builds the site from one branch while TinaCMS reads and writes content on `main`.

Fix: add `WORKERS_CI_BRANCH` and `CF_PAGES_BRANCH` to the chain.

Verified `WORKERS_CI_BRANCH` against the [Workers Builds configuration docs](https://developers.cloudflare.com/workers/ci-cd/builds/configuration/). Caught by @joshbermanssw in review of tinacms/tina.io#4697.
