### PR TITLE
fix: lazy-load deploy adapters so dev/build work on Windows ARM64

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,15 @@ The starter is host-neutral — it isn't tied to any one platform. Every content
 
 Set `SITE_URL` to your production URL — it feeds the sitemap, RSS, and OpenGraph tags; see `.env.example`. Most platforms inject their own deploy URL as a fallback, but Cloudflare Workers exposes none, so set `SITE_URL` there to avoid `localhost` canonicals.
 
+### Before your first deploy: TinaCloud credentials
+
+The default `pnpm build` compiles the CMS against TinaCloud, so it needs your project credentials. Without them it fails fast with `ERR_MISSING_CLOUD_CREDS`. Create a project at [app.tina.io](https://app.tina.io), then set `PUBLIC_TINA_CLIENT_ID` and `TINA_TOKEN` (see `.env.example`) in your host's environment variables.
+
+To build without TinaCloud — a purely local/offline build with no auth — run `pnpm build:local` instead, which skips the cloud checks.
+
 ## A note on React
 
-`react` and `react-dom@^18.3.1` are pinned in `devDependencies` for the TinaCMS admin UI build only — the site itself ships zero React. Without the pin, pnpm resolves `react@19` against `react-dom@18` and the admin crashes on init. This is tracked in [tinacms#6985](https://github.com/tinacms/tinacms/issues/6985); remove the pin once that lands.
+`react` and `react-dom` are both pinned to the same version (`^19.2.7`) in `devDependencies` for the TinaCMS admin UI build only — the site itself ships zero React. The pin keeps the two packages locked in lockstep; without it, pnpm's peer auto-install can pair mismatched `react` / `react-dom` versions and the admin crashes on init (`Cannot read properties of undefined (reading 'ReactCurrentDispatcher')`). This is tracked in [tinacms#6985](https://github.com/tinacms/tinacms/issues/6985); remove the pin once Tina declares `react` / `react-dom` as direct dependencies.
 
 ## Want to learn more?
 

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -14,13 +14,6 @@ import tailwindcss from '@tailwindcss/vite';
 // local `wrangler deploy`) falls back to a portable Node server. Set
 // DEPLOY_ADAPTER to force a specific adapter when no env var applies.
 async function getAdapter() {
-	// Lazy-load each adapter so only the selected platform's package is
-	// imported. A static top-level `import '@astrojs/cloudflare'` transitively
-	// loads `workerd`, which throws "Unsupported platform" at import time on
-	// platforms it ships no binary for (e.g. win32-arm64) — crashing `astro
-	// dev`/`build` before this function ever runs, even though local dev never
-	// selects Cloudflare. Dynamic import() defers each package to the branch
-	// that actually uses it. See https://github.com/tinacms/tinacms/issues/7190.
 	const vercel = async () => (await import('@astrojs/vercel')).default();
 	const cloudflare = async () => (await import('@astrojs/cloudflare')).default();
 	const netlify = async () => (await import('@astrojs/netlify')).default();

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -6,10 +6,6 @@ import icon from 'astro-icon';
 import tina from '@tinacms/astro/integration';
 import { tinaAdminDevRedirect } from '@tinacms/astro/vite';
 import tailwindcss from '@tailwindcss/vite';
-import node from '@astrojs/node';
-import vercel from '@astrojs/vercel';
-import cloudflare from '@astrojs/cloudflare';
-import netlify from '@astrojs/netlify';
 
 // Host-neutral: every content page prerenders to static HTML, and the one
 // on-demand route (/tina-island, the visual-editing endpoint) is served by
@@ -17,13 +13,25 @@ import netlify from '@astrojs/netlify';
 // automatically — nothing to configure — and any other host (including a
 // local `wrangler deploy`) falls back to a portable Node server. Set
 // DEPLOY_ADAPTER to force a specific adapter when no env var applies.
-function getAdapter() {
-	const nodeStandalone = node({ mode: 'standalone' });
+async function getAdapter() {
+	// Lazy-load each adapter so only the selected platform's package is
+	// imported. A static top-level `import '@astrojs/cloudflare'` transitively
+	// loads `workerd`, which throws "Unsupported platform" at import time on
+	// platforms it ships no binary for (e.g. win32-arm64) — crashing `astro
+	// dev`/`build` before this function ever runs, even though local dev never
+	// selects Cloudflare. Dynamic import() defers each package to the branch
+	// that actually uses it. See https://github.com/tinacms/tinacms/issues/7190.
+	const vercel = async () => (await import('@astrojs/vercel')).default();
+	const cloudflare = async () => (await import('@astrojs/cloudflare')).default();
+	const netlify = async () => (await import('@astrojs/netlify')).default();
+	const nodeStandalone = async () =>
+		(await import('@astrojs/node')).default({ mode: 'standalone' });
+
 	switch (process.env.DEPLOY_ADAPTER) {
 		case 'vercel': return vercel();
 		case 'cloudflare': return cloudflare();
 		case 'netlify': return netlify();
-		case 'node': return nodeStandalone;
+		case 'node': return nodeStandalone();
 		case undefined: break; // no override -> auto-detect below
 		default:
 			console.warn(`[astro.config] Unknown DEPLOY_ADAPTER "${process.env.DEPLOY_ADAPTER}" - ignoring and auto-detecting.`);
@@ -33,7 +41,7 @@ function getAdapter() {
 	if (process.env.WORKERS_CI || process.env.CF_PAGES) return cloudflare();
 	if (process.env.NETLIFY) return netlify();
 
-	return nodeStandalone;
+	return nodeStandalone();
 }
 
 // Prefer an explicit SITE_URL; otherwise use the URL the platform injects so
@@ -54,7 +62,7 @@ function getSiteUrl() {
 export default defineConfig({
 	site: getSiteUrl(),
 	output: 'static',
-	adapter: getAdapter(),
+	adapter: await getAdapter(),
 	redirects: { '/home': '/' },
 	integrations: [mdx(), sitemap(), icon(), tina()],
 	build: {


### PR DESCRIPTION
## Summary

Surfaced during the **Tester 2** validation of the Astro flagship starter (tinacms/tinacms#7182, run log tinacms/tinacms#7188). Two fixes, one file each:

### 1. `pnpm dev`/`build` crash on Windows ARM64 — closes #76 (mirror of tinacms/tinacms#7190)

`astro.config.mjs` statically imported all four deploy adapters at module scope:

```js
import node from '@astrojs/node';
import vercel from '@astrojs/vercel';
import cloudflare from '@astrojs/cloudflare';   // ← transitively loads workerd
import netlify from '@astrojs/netlify';
```

`@astrojs/cloudflare` pulls in `workerd`, which throws `Unsupported platform: win32 arm64 LE` **at import time** — before `getAdapter()` runs, so the starter crashes on win32-arm64 (Snapdragon X laptops etc.) regardless of which adapter would actually be selected.

**Fix:** lazy-load each adapter via dynamic `import()` inside `getAdapter()`, so only the selected platform's package is loaded. `getAdapter()` becomes `async` and the config uses top-level `await getAdapter()`.

### 2. Stale README docs — closes #77

- **"A note on React"** described a `react-dom@^18.3.1` pin that no longer exists (`package.json` pins `^19.2.7`). Rewrote to match the current lockstep pin and the actual `ReactCurrentDispatcher` failure mode (see tinacms/tinacms#6985).
- **"Deploying"** never mentioned that the default `pnpm build` requires TinaCloud credentials (`ERR_MISSING_CLOUD_CREDS`) or that `pnpm build:local` is the offline escape hatch. Added a short "Before your first deploy" note — the highest-friction gap called out in the Tester 2 review.

## Verification

- `astro.config.mjs` loads and auto-selects the **node** adapter locally (no platform env).
- `DEPLOY_ADAPTER=vercel` resolves the **vercel** adapter (thunk-call path works).
- No `@astrojs/cloudflare` import happens unless Cloudflare is actually selected, so `workerd` never loads on win32-arm64.
- Adapter resolution on Vercel/Cloudflare/Netlify build images (x64 Linux) is unaffected — same detection logic, just deferred.

## Not addressed here

- #78 (EPERM symlink on Windows Vercel-adapter build) — separate issue.
- The `ERR_MISSING_CLOUD_CREDS` **error-text** improvement lives in the `@tinacms/cli` (tinacms/tinacms) repo, not this starter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)